### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,4 @@ clear:
 .PHONY: clean
 clean: clear
 	rm -f $(addprefix $(ODIR)/, $(MONO_FILES) $(DOTNET_FILES) libsecrethub.so)
+

--- a/Makefile
+++ b/Makefile
@@ -24,25 +24,19 @@ compile: $(DEPS)
 	$(CC) -c -O2 -fpic -o $(ODIR)/secrethub_wrap.o $(ODIR)/secrethub_wrap.c
 	$(CC) -shared -fPIC $(OBJ) -o $(ODIR)/libsecrethub.so
 
-.PHONY: dotnet
-dotnet: client swig compile
+.PHONY: dotnet-test
+dotnet: $(ODIR)/libsecrethub.so
 	dotnet publish $(ODIR)/secrethub.csproj -o $(ODIR)
 	rm -r $(ODIR)/bin $(ODIR)/obj
-	$(MAKE) clear
 # 	dotnet $(ODIR)/secrethub.dll
 
-.PHONY: mono
-mono: client swig compile
+.PHONY: mono-test
+mono: $(ODIR)/libsecrethub.so
 	mono-csc -out:$(ODIR)/runme.exe $(ODIR)/*.cs
-	$(MAKE) clear
 # 	mono ./$(ODIR)/runme.exe
 
-.PHONY: clear
-clear:
+.PHONY: clean
+clean:
 	rm -f go.sum
 	rm -f $(addprefix $(ODIR)/, $(CGO_FILES) $(SWIG_FILES) $(OUT_FILES)) 
-
-.PHONY: clean
-clean: clear
 	rm -f $(addprefix $(ODIR)/, $(MONO_FILES) $(DOTNET_FILES) libsecrethub.so)
-

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+CGO_FILES=secrethub.a secrethub.h go.sum
+SWIG_FILES=secrethub.cs secrethub_wrap.c secrethubPINVOKE.cs Secret.cs SecretVersion.cs
+OUT_FILES=secrethub_wrap.o
+MONO_FILES=runme.exe
+DOTNET_FILES=secrethub secrethub.deps.json secrethub.dll secrethub.pdb secrethub.runtimeconfig.json
+SWIG=swig
+CC=gcc
+ODIR=./output
+DEPS=$(ODIR)/secrethub_wrap.c $(ODIR)/secrethub.h
+OBJ=$(ODIR)/secrethub_wrap.o $(ODIR)/secrethub.a
+
+all: client swig compile
+
+.PHONY: client
+client: secrethub_wrapper.go
+	go build -o output/secrethub.a -buildmode=c-archive secrethub_wrapper.go
+
+.PHONY: swig
+swig:
+	$(SWIG) -csharp $(ODIR)/secrethub.i
+
+.PHONY: compile
+compile: $(DEPS)
+	$(CC) -c -O2 -fpic -o $(ODIR)/secrethub_wrap.o $(ODIR)/secrethub_wrap.c
+	$(CC) -shared -fPIC $(OBJ) -o $(ODIR)/libsecrethub.so
+
+.PHONY: dotnet
+dotnet: client swig compile
+	dotnet publish $(ODIR)/secrethub.csproj -o $(ODIR)
+	rm -r $(ODIR)/bin $(ODIR)/obj
+	$(MAKE) clear
+# 	dotnet $(ODIR)/secrethub.dll
+
+.PHONY: mono
+mono: client swig compile
+	mono-csc -out:$(ODIR)/runme.exe $(ODIR)/*.cs
+	$(MAKE) clear
+# 	mono ./$(ODIR)/runme.exe
+
+.PHONY: clear
+clear:
+	rm -f go.sum
+	rm -f $(addprefix $(ODIR)/, $(CGO_FILES) $(SWIG_FILES) $(OUT_FILES)) 
+
+.PHONY: clean
+clean: clear
+	rm -f $(addprefix $(ODIR)/, $(MONO_FILES) $(DOTNET_FILES) libsecrethub.so)

--- a/output/build.sh
+++ b/output/build.sh
@@ -1,6 +1,0 @@
-go build -o secrethub.a -buildmode=c-archive ../secrethub_wrapper.go
-swig -csharp ./secrethub.i
-gcc -O2 -fPIC -c secrethub_wrap.c
-gcc -shared  secrethub_wrap.o secrethub.a  -o libsecrethub.so
-mono-csc -out:runme.exe *.cs
-rm secrethub.a secrethub_wrap.o secrethub_wrap.c secrethub.h secrethub.cs secrethubPINVOKE.cs SecretVersion.cs Secret.cs

--- a/output/secrethub.csproj
+++ b/output/secrethub.csproj
@@ -6,3 +6,4 @@
   </PropertyGroup>
 
 </Project>
+

--- a/output/secrethub.csproj
+++ b/output/secrethub.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This PR contains the Makefile that can be used in order to build easier the library and also the other necessary files to either run the C# file using Mono or .NET Core.

The structure of the Makefile is made so that no other external `build.sh` files are required, as well as other folders for generating the library for the 2 environments. `libsecrethub.go` is the same for both Mono and .NET Core. The only difference is in making the executable using a certain environment. The `output` folder is used to create that environment. 

The `Makefile` also contains the `clean` command which cleans all the files created alongside with the executable. In this way, you can easily test with both the compilers. 