### PR TITLE
Change client version from 1.0.0 to 0.1.0

### DIFF
--- a/secrethub_wrapper.go
+++ b/secrethub_wrapper.go
@@ -39,7 +39,7 @@ func Client() (*secrethub.Client, error) {
 	options := []secrethub.ClientOption{
 		secrethub.WithAppInfo(&secrethub.AppInfo{
 			Name:    "secrethub-xgo",
-			Version: "1.0.0",
+			Version: "0.1.0",
 		}),
 	}
 	client, err := secrethub.NewClient(options...)


### PR DESCRIPTION
Since the .NET client will be in beta for a while, the version number should be `0.1.0` instead.