### PR TITLE
Rename secrethub class to Client and put Client in SecretHub namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = bash
-CGO_FILES = secrethub.a secrethub.h go.sum
-SWIG_FILES = secrethub.cs secrethub_wrap.c secrethubPINVOKE.cs Secret.cs SecretVersion.cs
+CGO_FILES = Client.a Client.h go.sum
+SWIG_FILES = Client.cs secrethub_wrap.c ClientPINVOKE.cs Secret.cs SecretVersion.cs
 OUT_FILES = secrethub_wrap.o
 MONO_FILES = runme.exe
 DOTNET_FILES = secrethub secrethub.deps.json secrethub.dll secrethub.pdb secrethub.runtimeconfig.json
@@ -8,43 +8,43 @@ DOTNET_DIRS = $(ODIR)/bin $(ODIR)/obj
 SWIG = swig
 CC = gcc
 ODIR = ./output
-DEPS = $(ODIR)/secrethub_wrap.c $(ODIR)/secrethub.h
-OBJ = $(ODIR)/secrethub_wrap.o $(ODIR)/secrethub.a
+DEPS = $(ODIR)/secrethub_wrap.c $(ODIR)/Client.h
+OBJ = $(ODIR)/secrethub_wrap.o $(ODIR)/Client.a
 
 all: client swig compile
 
 .PHONY: client
 client: secrethub_wrapper.go
-	go build -o output/secrethub.a -buildmode=c-archive secrethub_wrapper.go
+	go build -o output/Client.a -buildmode=c-archive secrethub_wrapper.go
 
 .PHONY: swig
 swig:
-	$(SWIG) -csharp $(ODIR)/secrethub.i
+	$(SWIG) -csharp -namespace SecretHub $(ODIR)/secrethub.i
 
 .PHONY: compile
 compile: $(DEPS)
 	$(CC) -c -O2 -fpic -o $(ODIR)/secrethub_wrap.o $(ODIR)/secrethub_wrap.c
-	$(CC) -shared -fPIC $(OBJ) -o $(ODIR)/libsecrethub.so
+	$(CC) -shared -fPIC $(OBJ) -o $(ODIR)/libClient.so
 
 .PHONY: dotnet-test
-dotnet: $(ODIR)/libsecrethub.so
+dotnet: $(ODIR)/libClient.so
 	dotnet publish $(ODIR)/secrethub.csproj -o $(ODIR)
 	rm -r $(ODIR)/bin $(ODIR)/obj
 # 	dotnet $(ODIR)/secrethub.dll
 
 .PHONY: mono-test
-mono: $(ODIR)/libsecrethub.so
+mono: $(ODIR)/libClient.so
 	mono-csc -out:$(ODIR)/runme.exe $(ODIR)/*.cs
 # 	mono ./$(ODIR)/runme.exe
 
 .PHONY: nupkg
 nupkg: client swig compile
 	mkdir nuget
-	cp $(ODIR)/{libsecrethub.so,Secret.cs,secrethub.cs,secrethubPINVOKE.cs,SecretVersion.cs,secrethub.csproj} ./nuget/
+	cp $(ODIR)/{libClient.so,Secret.cs,Client.cs,ClientPINVOKE.cs,SecretVersion.cs,secrethub.csproj} ./nuget/
 	dotnet pack nuget/secrethub.csproj
 	mv ./nuget/bin/Debug/SecretHub.*.nupkg .
 	rm -r ./nuget
-	rm $(ODIR)/libsecrethub.so
+	rm $(ODIR)/libClient.so
 	make clean
 #.PHONY: nupkg-publish
 #nupkg-publish: nupkg
@@ -54,4 +54,4 @@ nupkg: client swig compile
 clean:
 	rm -f go.sum
 	rm -f $(addprefix $(ODIR)/, $(CGO_FILES) $(SWIG_FILES) $(OUT_FILES)) 
-	rm -f $(addprefix $(ODIR)/, $(MONO_FILES) $(DOTNET_FILES) libsecrethub.so)
+	rm -f $(addprefix $(ODIR)/, $(MONO_FILES) $(DOTNET_FILES) libClient.so)

--- a/output/secrethub.csproj
+++ b/output/secrethub.csproj
@@ -11,6 +11,6 @@
     </Description>
   </PropertyGroup>
     <ItemGroup>
-      <None Include="libsecrethub.so" Pack="true" PackagePath="runtimes\linux-x64\native" />
+      <None Include="libClient.so" Pack="true" PackagePath="runtimes\linux-x64\native" />
     </ItemGroup>
 </Project>

--- a/output/secrethub.i
+++ b/output/secrethub.i
@@ -1,9 +1,9 @@
-%module secrethub
+%module Client
 %{
-#include "secrethub.h"
+#include "Client.h"
 %}
 %include exception.i
-#include "secrethub.h"
+#include "Client.h"
 
 // Handle error message output parameters.
 %typemap(in, numinputs=0) char **errMessage (char *temp="") {


### PR DESCRIPTION
In order to make the generated C# code feel more like a C# (NuGet) package I made the following changes:
 - Renamed the class containing the exposed functions from `secrethub` to `Client`
 - Ensured that the `Client` class is placed in a namespace named `SecretHub` instead of being in the global namespace

Using the .NET client previously looked like this:
```c#
using System;
using static secrethub;

namespace dotnet_test
{
    class Program
    {
        static void Main(string[] args)
        {
            Console.WriteLine(secrethub.ReadString("secrethub-xgo/dotnet/test-secret"));
        }
    }
}
```

Now it looks like this:
```c#
using System;
using SecretHub;

namespace dotnet_test
{
    class Program
    {
        static void Main(string[] args)
        {
            Console.WriteLine(Client.ReadString("secrethub-xgo/dotnet/test-secret"));
        }
    }
}
```
or, alternatively
```c#
using System;

namespace dotnet_test
{
    class Program
    {
        static void Main(string[] args)
        {
            Console.WriteLine(SecretHub.Client.ReadString("secrethub-xgo/dotnet/test-secret"));
        }
    }
}
```