### PR TITLE
Build NuGet package for Windows (amd64)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ compile: $(DEPS)
 .PHONY: compile-win
 compile-win: $(DEPS)
 	x86_64-w64-mingw32-gcc -c -O2 -fpic -o $(ODIR)/secrethub_wrap.o $(ODIR)/secrethub_wrap.c
-	x86_64-w64-mingw32-gcc -shared -fPIC $(OBJ) -o $(ODIR)/libClient.dll
+	x86_64-w64-mingw32-gcc -shared -fPIC $(OBJ) -o $(ODIR)/Client.dll
 
 .PHONY: dotnet-test
 dotnet: $(ODIR)/libClient.so
@@ -50,7 +50,7 @@ mono: $(ODIR)/libClient.so
 .PHONY: nupkg
 nupkg: lib lib-win
 	mkdir nuget
-	cp $(ODIR)/{libClient.dll,libClient.so,Secret.cs,Client.cs,ClientPINVOKE.cs,SecretVersion.cs,secrethub.csproj} ./nuget/
+	cp $(ODIR)/{Client.dll,libClient.so,Secret.cs,Client.cs,ClientPINVOKE.cs,SecretVersion.cs,secrethub.csproj} ./nuget/
 	dotnet pack nuget/secrethub.csproj
 	mv ./nuget/bin/Debug/SecretHub.*.nupkg .
 	rm -r ./nuget
@@ -69,4 +69,4 @@ deps:
 clean:
 	rm -f go.sum
 	rm -f $(addprefix $(ODIR)/, $(CGO_FILES) $(SWIG_FILES) $(OUT_FILES)) 
-	rm -f $(addprefix $(ODIR)/, $(MONO_FILES) $(DOTNET_FILES) libClient.so libClient.dll)
+	rm -f $(addprefix $(ODIR)/, $(MONO_FILES) $(DOTNET_FILES) libClient.so Client.dll)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = bash
-CGO_FILES = secrethub.a secrethub.h go.sum
-SWIG_FILES = secrethub.cs secrethub_wrap.c secrethubPINVOKE.cs Secret.cs SecretVersion.cs
+CGO_FILES = Client.a Client.h go.sum
+SWIG_FILES = Client.cs secrethub_wrap.c ClientPINVOKE.cs Secret.cs SecretVersion.cs
 OUT_FILES = secrethub_wrap.o
 MONO_FILES = runme.exe
 DOTNET_FILES = secrethub secrethub.deps.json secrethub.dll secrethub.pdb secrethub.runtimeconfig.json
@@ -8,43 +8,43 @@ DOTNET_DIRS = $(ODIR)/bin $(ODIR)/obj
 SWIG = swig
 CC = gcc
 ODIR = ./output
-DEPS = $(ODIR)/secrethub_wrap.c $(ODIR)/secrethub.h
-OBJ = $(ODIR)/secrethub_wrap.o $(ODIR)/secrethub.a
+DEPS = $(ODIR)/secrethub_wrap.c $(ODIR)/Client.h
+OBJ = $(ODIR)/secrethub_wrap.o $(ODIR)/Client.a
 
 all: client swig compile
 
 .PHONY: client
 client: secrethub_wrapper.go
-	go build -o output/secrethub.a -buildmode=c-archive secrethub_wrapper.go
+	go build -o output/Client.a -buildmode=c-archive secrethub_wrapper.go
 
 .PHONY: swig
 swig:
-	$(SWIG) -csharp $(ODIR)/secrethub.i
+	$(SWIG) -csharp -namespace SecretHub $(ODIR)/secrethub.i
 
 .PHONY: compile
 compile: $(DEPS)
 	$(CC) -c -O2 -fpic -o $(ODIR)/secrethub_wrap.o $(ODIR)/secrethub_wrap.c
-	$(CC) -shared -fPIC $(OBJ) -o $(ODIR)/libsecrethub.so
+	$(CC) -shared -fPIC $(OBJ) -o $(ODIR)/libClient.so
 
 .PHONY: dotnet-test
-dotnet: $(ODIR)/libsecrethub.so
+dotnet: $(ODIR)/libClient.so
 	dotnet publish $(ODIR)/secrethub.csproj -o $(ODIR)
 	rm -r $(ODIR)/bin $(ODIR)/obj
 # 	dotnet $(ODIR)/secrethub.dll
 
 .PHONY: mono-test
-mono: $(ODIR)/libsecrethub.so
+mono: $(ODIR)/libClient.so
 	mono-csc -out:$(ODIR)/runme.exe $(ODIR)/*.cs
 # 	mono ./$(ODIR)/runme.exe
 
 .PHONY: nupkg
 nupkg: client swig compile
 	mkdir nuget
-	cp $(ODIR)/{libsecrethub.so,Secret.cs,secrethub.cs,secrethubPINVOKE.cs,SecretVersion.cs,secrethub.csproj} ./nuget/
+	cp $(ODIR)/{libClient.so,Secret.cs,Client.cs,ClientPINVOKE.cs,SecretVersion.cs,secrethub.csproj} ./nuget/
 	dotnet pack nuget/secrethub.csproj
 	mv ./nuget/bin/Debug/SecretHub.*.nupkg .
 	rm -r ./nuget
-	rm $(ODIR)/libsecrethub.so
+	rm $(ODIR)/libClient.so
 	make clean
 #.PHONY: nupkg-publish
 #nupkg-publish: nupkg
@@ -54,4 +54,4 @@ nupkg: client swig compile
 clean:
 	rm -f go.sum
 	rm -f $(addprefix $(ODIR)/, $(CGO_FILES) $(SWIG_FILES) $(OUT_FILES)) 
-	rm -f $(addprefix $(ODIR)/, $(MONO_FILES) $(DOTNET_FILES) libsecrethub.so)
+	rm -f $(addprefix $(ODIR)/, $(MONO_FILES) $(DOTNET_FILES) libClient.so)

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,11 @@ nupkg: lib lib-win
 #nupkg-publish: nupkg
 	#dotnet nuget push $(ODIR)/*.nupkg --api-key <API_KEY> --source 	https://api.nuget.org/v3/index.json
 
+.PHONY: deps
+deps:
+	sudo apt install gcc
+	sudo apt install gcc-mingw-w64
+
 .PHONY: clean
 clean:
 	rm -f go.sum

--- a/output/secrethub.csproj
+++ b/output/secrethub.csproj
@@ -12,6 +12,6 @@
   </PropertyGroup>
     <ItemGroup>
       <None Include="libClient.so" Pack="true" PackagePath="runtimes\linux-x64\native" />
-      <None Include="libClient.dll" Pack="true" PackagePath="runtimes\win10-x64\native" />
+      <None Include="Client.dll" Pack="true" PackagePath="runtimes\win10-x64\native" />
     </ItemGroup>
 </Project>

--- a/output/secrethub.csproj
+++ b/output/secrethub.csproj
@@ -11,6 +11,6 @@
     </Description>
   </PropertyGroup>
     <ItemGroup>
-      <None Include="libsecrethub.so" Pack="true" PackagePath="runtimes\linux-x64\native" />
+      <None Include="libClient.so" Pack="true" PackagePath="runtimes\linux-x64\native" />
     </ItemGroup>
 </Project>

--- a/output/secrethub.csproj
+++ b/output/secrethub.csproj
@@ -12,5 +12,6 @@
   </PropertyGroup>
     <ItemGroup>
       <None Include="libClient.so" Pack="true" PackagePath="runtimes\linux-x64\native" />
+      <None Include="libClient.dll" Pack="true" PackagePath="runtimes\win10-x64\native" />
     </ItemGroup>
 </Project>

--- a/output/secrethub.i
+++ b/output/secrethub.i
@@ -1,9 +1,9 @@
-%module secrethub
+%module Client
 %{
-#include "secrethub.h"
+#include "Client.h"
 %}
 %include exception.i
-#include "secrethub.h"
+#include "Client.h"
 
 // Handle error message output parameters.
 %typemap(in, numinputs=0) char **errMessage (char *temp="") {


### PR DESCRIPTION
This PR extends the building process to also build and include a `dll` for windows in the NuGet package.