### PR TITLE
Fix nupkg build error

### DIFF
--- a/dotnet/secrethub.csproj
+++ b/dotnet/secrethub.csproj
@@ -16,6 +16,6 @@
       <Compile Remove="test/UnitTest.cs" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Json.NET" Version="1.0.23" />
+      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
The import of `Json.Net` was not working, leading to failure in making the NuGet package.
The fix here solved it.