### PR TITLE
Remove `Secret` and `SecretVersion` constructor

### DIFF
--- a/secrethub.i
+++ b/secrethub.i
@@ -17,6 +17,10 @@
   }
 }
 
+// Do not generate a default constructor for the Secret and SecretVersion types.
+%nodefaultctor Secret;
+%nodefaultctor SecretVersion;
+
 extern struct Client {
     %extend {
         Client(char **errMessage);


### PR DESCRIPTION
This PR configures to not generate empty constructors for the `Secret` and `SecretVersion` types, as all the properties of these types are read only so there is no point in constructing them.